### PR TITLE
Muted path colours

### DIFF
--- a/map/src/config.js
+++ b/map/src/config.js
@@ -6,4 +6,22 @@ let difficultyColours = {
   'e': '200,35,35'
 }
 
-export { difficultyColours };
+let difficultyColoursMuted = {
+  'a': '150,200,150',
+  'c': '150,150,200',
+  'b': '150,200,200',
+  'd': '200,200,150',
+  'e': '200,150,150'
+}
+
+let familyFriendlyColours = {
+  'true': '51,204,51',
+  'false': '51,51,204'
+}
+
+let familyFriendlyColoursMuted = {
+  'true': '150,204,150',
+  'false': '150,150,204'
+}
+
+export { difficultyColours, difficultyColoursMuted, familyFriendlyColours, familyFriendlyColoursMuted };

--- a/map/src/main.js
+++ b/map/src/main.js
@@ -16,7 +16,7 @@ import { transform as transformCoord, transformExtent } from 'ol/proj';
 
 import Popup from 'ol-popup';
 
-import { difficultyColours } from './config.js';
+import { difficultyColours, difficultyColoursMuted, familyFriendlyColours, familyFriendlyColoursMuted } from './config.js';
 import { Tooltip } from './Tooltip.js';
 import InfoPanel from './InfoPanel.svelte';
 import FilterPanel from './FilterPanel.svelte';
@@ -399,10 +399,10 @@ class PathsToWellbeingMap {
   }
 
   routeOutlineStyle(mode) {
-    let opacity = mode === 'muted' ? 0.5 : 1;
+    let outlineColor = mode === 'muted' ? '#aaa' : 'black';
     let style = new Style({
       stroke: new Stroke({
-        color: 'black',
+        color: outlineColor,
         width: 7,
       }),
     });
@@ -413,10 +413,8 @@ class PathsToWellbeingMap {
   }
 
   routeDifficultyStyle(feature, mode) {
-    let opacity = mode === 'muted' ? 0.5 : 1;
-    let color = `rgba(${
-      difficultyColours[feature.get('difficultyuid')]
-    },${opacity})`;
+    let colors = mode === 'muted' ? difficultyColoursMuted : difficultyColours;
+    let color = `rgb(${colors[feature.get('difficultyuid')]})`;
     let style = new Style({
       stroke: new Stroke({
         color,
@@ -430,13 +428,11 @@ class PathsToWellbeingMap {
   }
 
   routeFamilyFriendlyStyle(feature, mode) {
-    let opacity = mode === 'muted' ? 0.5 : 1;
-    let color = `rgba(${
-      feature.get('family_friendly') ? '51,204,51' : '51,51,204'
-    },${opacity})`;
+    let colors = mode === 'muted' ? familyFriendlyColoursMuted : familyFriendlyColours;
+    let color = `rgb(${colors[feature.get('family_friendly')]})`;
     let style = new Style({
       stroke: new Stroke({
-        color: color,
+        color,
         width: 5,
       }),
     });
@@ -463,7 +459,7 @@ class PathsToWellbeingMap {
     new Style({
       zIndex: 1,
       stroke: new Stroke({
-        color: 'rgba(249,177,41)',
+        color: 'yellow',
         width: 13,
       }),
     }),

--- a/map/src/main.js
+++ b/map/src/main.js
@@ -436,7 +436,7 @@ class PathsToWellbeingMap {
         width: 5,
       }),
     });
-    if (mode == 'hover' || mode === 'selected') {
+    if (mode === 'hover' || mode === 'selected') {
       style.setZIndex(1);
     }
     return style;
@@ -449,7 +449,7 @@ class PathsToWellbeingMap {
         width: 11,
       }),
     });
-    if (mode = 'hover' || mode === 'selected') {
+    if (mode === 'hover' || mode === 'selected') {
       style.setZIndex(1);
     }
     return style;

--- a/map/src/main.js
+++ b/map/src/main.js
@@ -445,7 +445,7 @@ class PathsToWellbeingMap {
   routeHighlightStyle(mode) {
     let style = new Style({
       stroke: new Stroke({
-        color: 'yellow',
+        color: 'white',
         width: 11,
       }),
     });


### PR DESCRIPTION
The problem was that we were using opacity to fade colours. However, since the black line casing was actually a thick line behind the colours, this let more black show through, and hence darkened instead of fading.

The easiest fix would have been to add another style in between black outline and coloured line: a white opaque line so that opacity woud fade the colours properly. However, this would have added complexity and some processing overhead to the style.

Instead, I've created constants for the colours and muted colours for both family-friendly and difficulty catgorizations. Opacity is no longer used. This has the extra benefit of pulling the family-friendly colours into `config.js` alongside the difficulty colours.

I've also changed the hover and highlight colours, as the orange simply wasn't doing it for me.